### PR TITLE
add stoat

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
       - run: pip3 install ansi2html junit2html
 
       # generate html files from build outputs
-      - run: mix credo --strict > credo_output 
+      - run: mix credo --strict > credo_output || true
       - run: cat credo_output | ansi2html --t Credo -a -s solarized > credo.html
       - run: mix sobelow -v > sobelow_output
       - run: cat sobelow_output | ansi2html --t Sobelow -a -s solarized > sobelow.html

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,10 @@ jobs:
       - run: pip3 install ansi2html junit2html
 
       # generate html files from build outputs
-      - run: script -q /dev/null mix credo --strict | ansi2html --t Credo -a -s solarized > credo.html
-      - run: script -q /dev/null mix sobelow -v | ansi2html --t Sobelow -a -s solarized > sobelow.html
+      - run: mix credo --strict > credo_output 
+      - run: cat credo_output | ansi2html --t Credo -a -s solarized > credo.html
+      - run: mix sobelow -v > sobelow_output
+      - run: cat sobelow_output | ansi2html --t Sobelow -a -s solarized > sobelow.html
       - run: junit2html build/tests.xml tests.html
 
       - name: Run stoat action

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,6 @@ jobs:
       # generate html files from build outputs
       - run: script -q /dev/null mix credo --strict | ansi2html --t Credo -a -s solarized > credo.html
       - run: script -q /dev/null mix sobelow -v | ansi2html --t Sobelow -a -s solarized > sobelow.html
-
       - run: junit2html build/tests.xml tests.html
 
       - name: Run stoat action

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,4 +34,9 @@ jobs:
       # generate html files from build outputs
       - run: script -q /dev/null mix credo --strict | ansi2html --t Credo -a -s solarized > credo.html
       - run: script -q /dev/null mix sobelow -v | ansi2html --t Sobelow -a -s solarized > sobelow.html
+
       - run: junit2html build/tests.xml tests.html
+
+      - name: Run stoat action
+        uses: stoat-dev/stoat-action@v0
+        if: always()

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -4,14 +4,14 @@ enabled: true
 plugins:
   job_runtime:
     enabled: true
- static_hosting:
-   test-results:
-     path: hello/tests.html
-   test-coverage:
-     path: hello/cover/excoveralls.html
-   docs:
-     path: hello/doc
-   credo-report:
-     path: hello/tests.html
-   sobelow-report:
-     path: hello/tests.html
+  static_hosting:
+    test-results:
+      path: hello/tests.html
+    test-coverage:
+      path: hello/cover/excoveralls.html
+    docs:
+      path: hello/doc
+    credo-report:
+      path: hello/tests.html
+    sobelow-report:
+      path: hello/tests.html

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -1,0 +1,17 @@
+---
+version: 1
+enabled: true
+plugins:
+  job_runtime:
+    enabled: true
+ static_hosting:
+   test-results:
+     path: hello/tests.html
+   test-coverage:
+     path: hello/cover/excoveralls.html
+   docs:
+     path: hello/doc
+   credo-report:
+     path: hello/tests.html
+   sobelow-report:
+     path: hello/tests.html

--- a/.stoat/config.yaml
+++ b/.stoat/config.yaml
@@ -12,6 +12,6 @@ plugins:
     docs:
       path: hello/doc
     credo-report:
-      path: hello/tests.html
+      path: hello/credo.html
     sobelow-report:
-      path: hello/tests.html
+      path: hello/sobelow.html


### PR DESCRIPTION
Here is an example of how to use [Stoat](https://stoat.dev) for an Elixir Phoenix project created in https://github.com/stoat-dev/example-elixir/pull/1.

We capture outputs from the build and make all of these accessible in one click:
- Test results from [ExUnit](https://hexdocs.pm/ex_unit/ExUnit.html) converted from JUnit XML to HTML
- Test coverage using [ExCoveralls](https://github.com/parroty/excoveralls)
- Docs using [ex_doc](https://github.com/elixir-lang/ex_doc)
- [Credo](https://github.com/rrrene/credo) reports converted to HTML
- [sobelow](https://github.com/nccgroup/sobelow) reports converted to HTML

Learn how to use Stoat at https://docs.stoat.dev/